### PR TITLE
Added examples to OneSumNode in SeymoursDecomposition.pyx

### DIFF
--- a/src/sage/matrix/seymour_decomposition.pyx
+++ b/src/sage/matrix/seymour_decomposition.pyx
@@ -193,14 +193,29 @@ cdef class SumNode(DecompositionNode):
 
     summands = DecompositionNode._children
 
+    def get_children_matrices(self):
+        return tuple(ch.matrix() for ch in self._children())
 
 cdef class OneSumNode(SumNode):
 
-    pass
+    def block_diagonal_repr(self):
+        return block_diagonal_matrix(*self.get_children_matrices(), sparse = True)
+
+#     def permuted_block_matrix(self):
+#         rows, cols = self.parent_rows_and_columns()
+#         BlockMatrix = self.block_diagonal_repr()
+#         Prows, Pcols = []
+#         for ch in self._children:
+#             chrows, chcols = ch.parent_rows_and_columns()
+#             for i in range(len(chrows)):
+#                 Prows.append(chrows[i])
+#             for j in range(len(chcols)):
+#                 Pcols.append(chcols[i])
+
 
 
 cdef class TwoSumNode(SumNode):
-
+    
     pass
 
 

--- a/src/sage/matrix/seymour_decomposition.pyx
+++ b/src/sage/matrix/seymour_decomposition.pyx
@@ -199,8 +199,7 @@ cdef class SumNode(DecompositionNode):
 cdef class OneSumNode(SumNode):
 
     def block_diagonal_repr(self):
-        from sage.matrix.special import block_diagonal_matrix
-        return block_diagonal_matrix(*self.get_children_matrices(), sparse = True)
+        return one_sum(*self.get_children_matrices())
 
 #     def permuted_block_matrix(self):
 #         rows, cols = self.parent_rows_and_columns()

--- a/src/sage/matrix/seymour_decomposition.pyx
+++ b/src/sage/matrix/seymour_decomposition.pyx
@@ -199,6 +199,7 @@ cdef class SumNode(DecompositionNode):
 cdef class OneSumNode(SumNode):
 
     def block_diagonal_repr(self):
+        from sage.matrix.special import block_diagonal_matrix
         return block_diagonal_matrix(*self.get_children_matrices(), sparse = True)
 
 #     def permuted_block_matrix(self):

--- a/src/sage/matrix/seymour_decomposition.pyx
+++ b/src/sage/matrix/seymour_decomposition.pyx
@@ -162,8 +162,8 @@ cdef class DecompositionNode(SageObject):
         EXAMPLES::
 
             sage: from sage.matrix.matrix_cmr_sparse import Matrix_cmr_chr_sparse
-            sage: M = Matrix_cmr_chr_sparse.one_sum([[1, 0], [-1, 1]], [[1, 1], [-1, 0]], [[1, 0], [0,1]]
-            ....: ); M
+            sage: M = Matrix_cmr_chr_sparse.one_sum([[1, 0], [-1, 1]],
+            ....: [[1, 1], [-1, 0]], [[1, 0], [0,1]]); M
             [ 1  0| 0  0| 0  0]
             [-1  1| 0  0| 0  0]
             [-----+-----+-----]
@@ -177,8 +177,8 @@ cdef class DecompositionNode(SageObject):
             sage: certificate._children()
             (GraphicNode, GraphicNode, GraphicNode, GraphicNode)
 
-            sage: M2 = Matrix_cmr_chr_sparse(MatrixSpace(ZZ, 2, 2, sparse=True), [[1, 1], [-
-            ...: 1, 0]]); M2
+            sage: M2 = Matrix_cmr_chr_sparse(MatrixSpace(ZZ, 2, 2, sparse=True),
+            ...:  [[1, 1], [-1, 0]]); M2
             [ 1  1]
             [-1  0]
             sage: result, certificate = M.is_totally_unimodular(certificate=True); certificate
@@ -250,7 +250,7 @@ cdef class OneSumNode(SumNode):
             [ 0  0|-1  0]
 
             sage: M3 = Matrix_cmr_chr_sparse.one_sum([[1, 0], [-1, 1]], [[1, 1], [-1, 0]], [[1, 0], [0,1]]
-            ....: ); M3
+            ....: [[1, 1], [-1, 0]], [[1, 0], [0,1]]); M3
             [ 1  0| 0  0| 0  0]
             [-1  1| 0  0| 0  0]
             [-----+-----+-----]

--- a/src/sage/matrix/seymour_decomposition.pyx
+++ b/src/sage/matrix/seymour_decomposition.pyx
@@ -194,24 +194,62 @@ cdef class SumNode(DecompositionNode):
     summands = DecompositionNode._children
 
     def get_children_matrices(self):
+        if self._children() is None:
+            raise ValueError('Node has no children')
         return tuple(ch.matrix() for ch in self._children())
+
 
 cdef class OneSumNode(SumNode):
 
     def block_diagonal_repr(self):
-        return one_sum(*self.get_children_matrices())
+        r"""
+        EXAMPLES::
 
-#     def permuted_block_matrix(self):
-#         rows, cols = self.parent_rows_and_columns()
-#         BlockMatrix = self.block_diagonal_repr()
-#         Prows, Pcols = []
-#         for ch in self._children:
-#             chrows, chcols = ch.parent_rows_and_columns()
-#             for i in range(len(chrows)):
-#                 Prows.append(chrows[i])
-#             for j in range(len(chcols)):
-#                 Pcols.append(chcols[i])
+            sage: from sage.matrix.matrix_cmr_sparse import Matrix_cmr_chr_sparse
+            sage: M = Matrix_cmr_chr_sparse.one_sum([[1, 0], [-1, 1]], [[1, 1], [-1, 0]])
+            sage: result, certificate = M.is_totally_unimodular(certificate=True); certificate
+            OneSumNode with 2 children
+            sage: certificate.get_children_matrices()
+            (
+            [ 1  0]  [ 1  1]
+            [-1  1], [-1  0]
+            )
+            sage: certificate.block_diagonal_repr()
+            [ 1  0| 0  0]
+            [-1  1| 0  0]
+            [-----+-----]
+            [ 0  0| 1  1]
+            [ 0  0|-1  0]
 
+            sage: M3 = Matrix_cmr_chr_sparse.one_sum([[1, 0], [-1, 1]], [[1, 1], [-1, 0]], [[1, 0], [0,1]]
+            ....: ); M3
+            [ 1  0| 0  0| 0  0]
+            [-1  1| 0  0| 0  0]
+            [-----+-----+-----]
+            [ 0  0| 1  1| 0  0]
+            [ 0  0|-1  0| 0  0]
+            [-----+-----+-----]
+            [ 0  0| 0  0| 1  0]
+            [ 0  0| 0  0| 0  1]
+            sage: result, certificate = M3.is_totally_unimodular(certificate=True); certificate
+            OneSumNode with 4 children
+            sage: certificate.get_children_matrices()
+            (
+            [ 1  0]       [ 1  1]
+            [-1  1], [1], [-1  0], [1]
+            )
+            sage: certificate.block_diagonal_repr()
+            [ 1  0| 0  0| 0| 0]
+            [-1  1| 0  0| 0| 0]
+            [-----+-----+--+--]
+            [ 0  0| 1  1| 0| 0]
+            [ 0  0|-1  0| 0| 0]
+            [-----+-----+--+--]
+            [ 0  0| 0  0| 1| 0]
+            [-----+-----+--+--]
+            [ 0  0| 0  0| 0| 1]
+        """
+        return Matrix_cmr_chr_sparse.one_sum(*self.get_children_matrices())
 
 
 cdef class TwoSumNode(SumNode):


### PR DESCRIPTION
<!-- Please provide a concise, informative and self-explanatory title. -->
<!-- Don't put issue numbers in the title. Put it in the Description below. -->
<!-- For example, instead of "Fixes #12345", use "Add a new method to multiply two integers" -->

### :books: Description

<!-- Describe your changes here in detail. --> Added method for block matrix representation of a one-sum node. Issue found with one_sum method in matrix_cmr_sparse.pyx, found as follows:

sage: from sage.matrix.matrix_cmr_sparse import Matrix_cmr_chr_sparse
sage: M3 = Matrix_cmr_chr_sparse.one_sum([[1, 0], [-1, 1]], [[1, 1], [-1, 0]], [[1, 0], [0,1]]
....: 
....:             ....: ); M3
[ 1  0| 0  0| 0  0]
[-1  1| 0  0| 0  0]
[-----+-----+-----]
[ 0  0| 1  1| 0  0]
[ 0  0|-1  0| 0  0]
[-----+-----+-----]
[ 0  0| 0  0| 1  0]
[ 0  0| 0  0| 0  1]
sage: result, certificate = M3.is_totally_unimodular(certificate=True); certificate
OneSumNode with 4 children
sage: certificate.block_diagonal_repr()
[ 1  0| 0  0| 0| 0]
[-1  1| 0  0| 0| 0]
[-----+-----+--+--]
[ 0  0| 1  1| 0| 0]
[ 0  0|-1  0| 0| 0]
[-----+-----+--+--]
[ 0  0| 0  0| 1| 0]
[-----+-----+--+--]
[ 0  0| 0  0| 0| 1]
sage: type(certificate)
<class 'sage.matrix.seymour_decomposition.OneSumNode'>
sage: certificate.block_diagonal_repr()
---------------------------------------------------------------------------
OverflowError                             Traceback (most recent call last)
Cell In [7], line 1
----> 1 certificate.block_diagonal_repr()

File ~/sage/worktree-cmr/src/sage/matrix/seymour_decomposition.pyx:252, in sage.matrix.seymour_decomposition.OneSumNode.block_diagonal_repr()
    250     [ 0  0| 0  0| 0| 1]
    251 """
--> 252 return Matrix_cmr_chr_sparse.one_sum(*self.get_children_matrices())
    253 
    254 

File ~/sage/worktree-cmr/src/sage/matrix/seymour_decomposition.pyx:199, in genexpr()
    197 if self._children() is None:
    198     raise ValueError('Node has no children')
--> 199 return tuple(ch.matrix() for ch in self._children())
    200 
    201 

File ~/sage/worktree-cmr/src/sage/matrix/seymour_decomposition.pyx:199, in genexpr()
    197 if self._children() is None:
    198     raise ValueError('Node has no children')
--> 199 return tuple(ch.matrix() for ch in self._children())
    200 
    201 

File ~/sage/worktree-cmr/src/sage/misc/cachefunc.pyx:2301, in sage.misc.cachefunc.CachedMethodCallerNoArgs.__call__()
   2299 if self.cache is None:
   2300     f = self.f
-> 2301     self.cache = f(self._instance)
   2302 return self.cache
   2303 

File ~/sage/worktree-cmr/src/sage/matrix/seymour_decomposition.pyx:59, in sage.matrix.seymour_decomposition.DecompositionNode.matrix()
     57 if mat == NULL:
     58     return None
---> 59 ms = MatrixSpace(ZZ, mat.numRows, mat.numColumns, sparse=True)
     60 result = Matrix_cmr_chr_sparse.__new__(Matrix_cmr_chr_sparse, ms)
     61 result._mat = mat

File ~/sage/worktree-cmr/src/sage/misc/classcall_metaclass.pyx:320, in sage.misc.classcall_metaclass.ClasscallMetaclass.__call__()
    318 """
    319 if cls.classcall is not None:
--> 320     return cls.classcall(cls, *args, **kwds)
    321 else:
    322     # Fast version of type.__call__(cls, *args, **kwds)

File ~/sage/worktree-cmr/src/sage/matrix/matrix_space.py:587, in MatrixSpace.__classcall__(cls, base_ring, nrows, ncols, sparse, implementation, **kwds)
    585     raise ArithmeticError("ncols must be nonnegative")
    586 if nrows > sys.maxsize or ncols > sys.maxsize:
--> 587     raise OverflowError("number of rows and columns may be at most %s" % sys.maxsize)
    589 matrix_cls = get_matrix_class(base_ring, nrows, ncols, sparse, implementation)
    590 return super().__classcall__(cls, base_ring, nrows,
    591                              ncols, sparse, matrix_cls, **kwds)

OverflowError: number of rows and columns may be at most 9223372036854775807

<!-- Why is this change required? What problem does it solve? -->
<!-- If this PR resolves an open issue, please link to it here. For example "Fixes #12345". -->
<!-- If your change requires a documentation PR, please link it appropriately. -->

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. It should be `[x]` not `[x ]`. -->

- [x ] The title is concise, informative, and self-explanatory.
- [ ] The description explains in detail what this PR is about.
- [ ] I have linked a relevant issue or discussion.
- [ ] I have created tests covering the changes.
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
- #12345: short description why this is a dependency
- #34567: ...
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
