### PR TITLE
Run ctest once more with more detailed output.

### DIFF
--- a/build/pkgs/cmr/spkg-check.in
+++ b/build/pkgs/cmr/spkg-check.in
@@ -1,3 +1,4 @@
 cd src
 cd build
 ctest
+ctest --rerun-failed --output-on-failure 


### PR DESCRIPTION
After ctest executes the unittests and one fails, there currently is not much feedback. This change will, upon error, re-run the failed tests and actually print the output. This help debugging.