### PR TITLE
add __round__ to the customized mpmath mpf class

### DIFF
--- a/src/sage/libs/mpmath/ext_main.pyx
+++ b/src/sage/libs/mpmath/ext_main.pyx
@@ -1815,7 +1815,7 @@ cdef class mpf_base(mpnumber):
             sage: X().to_fixed(30)
             3489660928
         """
-        return libmp.to_fixed(self._mpf_, prec)
+        return libmp.to_fixed(self._mpf_, prec)    
 
     def __getstate__(self):
         return libmp.to_pickable(self._mpf_)
@@ -2135,6 +2135,9 @@ cdef class mpf(mpf_base):
         MPF_sqrt(&r.value, &s.value, global_opts)
         return r
 
+    def __round__(self, *args):
+        return round(float(self), *args)
+    
     def __richcmp__(self, other, int op):
         """
         Compares numbers ::


### PR DESCRIPTION
This PR just add the `__round__` method in sage.libs.mpmath.mpf class. This is necessary for compatibility with Mathics, and must fix  #37395.

### :memo: Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!-- Feel free to remove irrelevant items. -->

- [x] The title is concise, informative, and self-explanatory.
- [x] The description explains in detail what this PR is about.
- [x] I have linked a relevant issue or discussion.
- [] I have created tests covering the changes.   
- [ ] I have updated the documentation accordingly.

### :hourglass: Dependencies

<!-- List all open PRs that this PR logically depends on
-  #37395
-->

<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
